### PR TITLE
add missing dependency and command

### DIFF
--- a/boot/readme.md
+++ b/boot/readme.md
@@ -3,11 +3,13 @@
 
 To generate this file yourself, do the following on any computer:
 
-$ sudo apt-get install git bison libopts25 libselinux1-dev autogen m4 autoconf help2man libopts25-dev flex libfont-freetype-perl automake autotools-dev libfreetype6-dev texinfo
+$ sudo apt-get install git bison libopts25 libselinux1-dev autogen m4 autoconf help2man libopts25-dev flex libfont-freetype-perl automake autotools-dev libfreetype6-dev texinfo autopoint
 
 $ git clone git://git.savannah.gnu.org/grub.git
 
 $ cd grub
+
+$ ./bootstrap
 
 $ ./autogen.sh
 


### PR DESCRIPTION
First, thank you so much for this. It was the only piece of advice I could find anywhere on how to get linux on my old transformer tablet.
I just did this whole process and had some issues, for which I've set the required commands i had to use in here for future reference. Basically just `autopoint` was missing as a dependency and grub's `autogen.sh` required `./bootstrap` to be executed first.